### PR TITLE
Fix sort icon size

### DIFF
--- a/src/styles/md-table.less
+++ b/src/styles/md-table.less
@@ -81,6 +81,8 @@ table.md-table {
       width: 16px;
       font-size: 16px !important;
       line-height: 16px !important;
+      min-height: 16px;
+      min-width: 16px;
 
       &.md-sort-icon {
         color: @md-dark-disabled;


### PR DESCRIPTION
Recent version of Angular Material set
```
min-height: 24px;
min-width: 24px;
```
that prevents the icon to show at expected size (16px).